### PR TITLE
Config capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ group :test do
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
   gem 'capybara'
+  gem 'selenium-webdriver'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group :test do
   gem 'rspec-mocks'
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
+  gem 'capybara'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,12 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.0)
     builder (3.2.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -160,11 +166,14 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     will_paginate (3.0.7)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   coffee-rails (~> 4.0.0)
   factory_girl_rails
   jbuilder (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.5.6)
+      ffi (~> 1.0, >= 1.0.11)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -59,6 +61,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    ffi (1.9.10)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     hike (1.2.3)
@@ -126,12 +129,18 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
+    rubyzip (1.1.7)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    selenium-webdriver (2.46.2)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     simple_form (3.1.0)
@@ -165,6 +174,7 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    websocket (1.2.2)
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -183,6 +193,7 @@ DEPENDENCIES
   rspec-mocks
   rspec-rails (~> 3.0.0)
   sass-rails (~> 4.0.0)
+  selenium-webdriver
   shoulda-matchers
   simple_form
   slim

--- a/app/views/courses/_form.html.slim
+++ b/app/views/courses/_form.html.slim
@@ -4,8 +4,8 @@
       .well
         = simple_form_for @course, { class: 'form-horizontal' } do |f|
           .form-group
-            = f.input :name, placeholder: t('simple_form.placeholders.course.name'), label: false
+            = f.input :name, placeholder: t('simple_form.placeholders.course.name')
           .form-group
-            = f.text_area :description, placeholder: t('simple_form.placeholders.course.description'), label: false, size: 25
+            = f.text_area :description, placeholder: t('simple_form.placeholders.course.description'), size: 25
           .panel-footer
             = f.submit

--- a/spec/features/courses/courses_new_spec.rb
+++ b/spec/features/courses/courses_new_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Page to add new course', type: :feature do
+  feature 'show the page to add new course' do
+    scenario 'see the fields' do
+      visit new_course_path
+
+      fill_in 'Nome', with: 'TI'
+      fill_in 'Descrição do Curso', with: 'TI TI'
+
+      click_button('Criar Curso')
+
+      expect(current_path).to eq(courses_path)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,8 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'capybara/rspec'
+require 'capybara/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,15 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'
 
+Capybara.current_driver = :selenium
+
+Capybara.register_driver :selenium do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.default_wait_time = 10
+Capybara.current_driver = :selenium
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Add capybara + webdriver.

Para usar o webdriver foi necessário baixar o webdriver http://chromedriver.storage.googleapis.com/index.html?path=2.12/ de acordo com a versão do chrome, colocar na pastar `/usr/bin` e dar permissão `chmod 755 arquivo`.

Executar `rspec`
